### PR TITLE
Window title not updated when using "Custom Title Bar"

### DIFF
--- a/lib/custom-window-title.coffee
+++ b/lib/custom-window-title.coffee
@@ -94,7 +94,10 @@ module.exports =
 
 					if filePath or projectPath
 						atom.setRepresentedFilename(filePath ? projectPath)
-					document.title = title
+					if document.getElementsByClassName("title-bar")[0]
+						document.getElementsByClassName("title-bar")[0].getElementsByClassName("title")[0].innerText = title
+					else
+						document.title = title
 				catch e
 					_updateWindowTitle.call(this)
 			else


### PR DESCRIPTION
This fixes #5. All credit goes to @davidolrik, he [suggested](https://github.com/pixilz/custom-window-title/issues/5#issuecomment-337179895) this change.